### PR TITLE
Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+before_script: "sh -e /etc/init.d/xvfb start && sudo aptitude -y -q install unzip chromium-browser"
+script: "bundle exec rake travis"
+rvm:
+  - 1.9.2

--- a/Rakefile
+++ b/Rakefile
@@ -9,3 +9,13 @@ task :test do
   end
   task("tests").execute
 end
+
+task :travis do
+  puts "Grabbing chromedriver..."
+  mkdir_p "/tmp/bin"
+  system "cd /tmp/bin && wget http://chromium.googlecode.com/files/chromedriver_linux32_16.0.902.0.zip && unzip chromedriver_linux32_16.0.902.0.zip"
+
+  puts "Starting to run tests..."
+  system("export PATH=/tmp/bin:$PATH && export DISPLAY=:99.0 && bundle exec rake test")
+  raise "`rake test` failed!" unless $?.exitstatus == 0
+end


### PR DESCRIPTION
This pull request can't be merged yet. It doesn't work. Not sure how to fix this error, though:

```
1) Error:
142test_0004_gets_a_list_of_the_paths_in_the_results(HitAListOfPathsForThisAppSpec):
143Selenium::WebDriver::Error::UnknownError: Internal Chrome error during 'CaptureEntirePage': (Taking a page snapshot is not supported on this platform). Request details: ({"command":"CaptureEntirePage","path":"/tmp/.com.google.Chrome.TmAlv4/screen","tab_index":0,"windex":0}).
144Backtrace:
1450x8088d3a
1460x8076225
1470x807116b
1480x8076c68
1490x8078b82
1500x8076d31
1510x8097dc5
1520x80a1d5e
1530x80a2bff
1540x80a3f7c
1550x80a502e
1560x80a7a40
1570x80a2464
1580x80a24cd
1590x809847d
1600x809833e
1610x809813c
162start_thread [0xc81e99]
1630xd6573e
164
165/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/remote/response.rb:50:in `assert_ok'
166/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/remote/response.rb:15:in `initialize'
167/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/remote/http/common.rb:58:in `new'
168/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/remote/http/common.rb:58:in `create_response'
169/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/remote/http/default.rb:64:in `request'
170/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/remote/http/common.rb:39:in `call'
171/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/remote/bridge.rb:450:in `raw_execute'
172/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/remote/bridge.rb:428:in `execute'
173/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/remote/bridge.rb:230:in `getScreenshot'
174/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/common/driver_extensions/takes_screenshot.rb:34:in `screenshot_as'
175/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/common/driver_extensions/takes_screenshot.rb:18:in `block in save_screenshot'
176/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/common/driver_extensions/takes_screenshot.rb:18:in `open'
177/home/vagrant/.rvm/gems/ruby-1.9.2-p290/gems/selenium-webdriver-2.14.0/lib/selenium/webdriver/common/driver_extensions/takes_screenshot.rb:18:in `save_screenshot'
178/home/vagrant/builds/steveklabnik/compatriot/lib/compatriot/browser.rb:39:in `screenshot'
179/home/vagrant/builds/steveklabnik/compatriot/lib/compatriot/browser.rb:28:in `block in take_screenshots'
180/home/vagrant/builds/steveklabnik/compatriot/lib/compatriot/browser.rb:26:in `each'
181/home/vagrant/builds/steveklabnik/compatriot/lib/compatriot/browser.rb:26:in `take_screenshots'
182/home/vagrant/builds/steveklabnik/compatriot/lib/compatriot/results.rb:16:in `take_screenshots'
183/home/vagrant/builds/steveklabnik/compatriot/lib/compatriot/runner.rb:26:in `block in take_screenshots'
184/home/vagrant/builds/steveklabnik/compatriot/lib/compatriot/runner.rb:25:in `each'
185/home/vagrant/builds/steveklabnik/compatriot/lib/compatriot/runner.rb:25:in `take_screenshots'
186/home/vagrant/builds/steveklabnik/compatriot/lib/compatriot/runner.rb:7:in `start'
187/home/vagrant/builds/steveklabnik/compatriot/spec/list_of_app_paths_spec.rb:19:in `block (2 levels) in <top (required)>'
```
