### PR TITLE
Pull assertions into compatriot to make for easier setup

### DIFF
--- a/lib/compatriot.rb
+++ b/lib/compatriot.rb
@@ -6,7 +6,7 @@ require "compatriot/image_differ/image_differ"
 
 module Compatriot
   class << self
-    attr_accessor :app, :screenshot_directory
+    attr_accessor :app, :screenshot_directory, :ui_difference_threshold
 
     def configure
       yield self
@@ -51,5 +51,6 @@ module Compatriot
 
   Compatriot.configure do |config|
     config.screenshot_directory = './compatriot/screenshots'
+    config.ui_difference_threshold  = 0
   end
 end

--- a/lib/compatriot.rb
+++ b/lib/compatriot.rb
@@ -7,7 +7,8 @@ require "compatriot/image_differ/image_differ"
 
 module Compatriot
   class << self
-    attr_accessor :app, :screenshot_directory, :ui_difference_threshold
+    attr_accessor :app, :screenshot_directory,
+                  :ui_difference_threshold, :framework
 
     def configure
       yield self
@@ -17,7 +18,7 @@ module Compatriot
       Compatriot::Runner.start(app, paths)
     end
 
-    def take_screenshot(page, test, description)
+    def take_screenshot(test, description)
       filename = filename_for_test(test, description)
       control_image_path = filepath_for_screenshot('control', filename)
 
@@ -26,11 +27,11 @@ module Compatriot
       else
         screenshot_type = 'control'
       end
-      page.save_screenshot filepath_for_screenshot(screenshot_type, filename)
+      framework.current_session.save_screenshot filepath_for_screenshot(screenshot_type, filename)
     end
 
-    def percentage_changed(page, test, description = '')
-      variable_img_path = take_screenshot(page, test, description)
+    def percentage_changed(test, description = '')
+      variable_img_path = take_screenshot(test, description)
       control_img_path = filepath_for_screenshot('control', filename_for_test(test, description))
       diff = Compatriot::ColorDiffer.diff(variable_img_path, control_img_path, self.screenshot_directory + '/')
       variable_image = ChunkyPNG::Image.from_file(variable_img_path)
@@ -53,5 +54,6 @@ module Compatriot
   Compatriot.configure do |config|
     config.screenshot_directory = './compatriot/screenshots'
     config.ui_difference_threshold  = 0.0
+    config.framework = Capybara #only supporting capybara until someone wants to support something else
   end
 end

--- a/lib/compatriot.rb
+++ b/lib/compatriot.rb
@@ -8,7 +8,8 @@ require "compatriot/image_differ/image_differ"
 module Compatriot
   class << self
     attr_accessor :app, :screenshot_directory,
-                  :ui_difference_threshold, :framework
+                  :ui_difference_threshold, :framework,
+                  :show_diffs
 
     def configure
       yield self
@@ -55,5 +56,6 @@ module Compatriot
     config.screenshot_directory = './compatriot/screenshots'
     config.ui_difference_threshold  = 0.05
     config.framework = Capybara #only supporting capybara until someone wants to support something else
+    config.show_diffs = false
   end
 end

--- a/lib/compatriot.rb
+++ b/lib/compatriot.rb
@@ -53,7 +53,7 @@ module Compatriot
 
   Compatriot.configure do |config|
     config.screenshot_directory = './compatriot/screenshots'
-    config.ui_difference_threshold  = 0.0
+    config.ui_difference_threshold  = 0.05
     config.framework = Capybara #only supporting capybara until someone wants to support something else
   end
 end

--- a/lib/compatriot.rb
+++ b/lib/compatriot.rb
@@ -1,3 +1,4 @@
+require "compatriot/assertions"
 require "compatriot/version"
 require "compatriot/runner"
 require "compatriot/browser"
@@ -51,6 +52,6 @@ module Compatriot
 
   Compatriot.configure do |config|
     config.screenshot_directory = './compatriot/screenshots'
-    config.ui_difference_threshold  = 0
+    config.ui_difference_threshold  = 0.0
   end
 end

--- a/lib/compatriot/assertions.rb
+++ b/lib/compatriot/assertions.rb
@@ -1,6 +1,14 @@
 module Compatriot::Assertions
   def assert_no_ui_changes(title = '')
     diff = Compatriot.percentage_changed(self, title)
-    assert diff <= Compatriot.ui_difference_threshold, "The difference in the page (#{diff}%) is greater then the threshold #{Compatriot.ui_difference_threshold}"
+    diff_file = Compatriot.filepath_for_screenshot('diffs', Compatriot.filename_for_test(self, title))
+    puts "% diff is #{diff}. #{diff_file}" if Compatriot.show_diffs
+    pass = diff <= Compatriot.ui_difference_threshold
+
+    unless pass
+      puts "Diff > ThresholdFailed: see #{diff_file}"
+    end
+
+    assert pass, "The difference in the page (#{diff}%) is greater then the threshold #{Compatriot.ui_difference_threshold}"
   end
 end

--- a/lib/compatriot/assertions.rb
+++ b/lib/compatriot/assertions.rb
@@ -1,8 +1,6 @@
-module Compatriot
-  module Assertions
-    def assert_no_ui_changes(title = '')
-      diff = Compatriot.percentage_changed(self, title)
-      assert diff <= Compatriot.ui_difference_threshold, "The difference in the page (#{diff}%) is greater then the threshold #{Compatriot.ui_difference_threshold}"
-    end
+module Compatriot::Assertions
+  def assert_no_ui_changes(title = '')
+    diff = Compatriot.percentage_changed(self, title)
+    assert diff <= Compatriot.ui_difference_threshold, "The difference in the page (#{diff}%) is greater then the threshold #{Compatriot.ui_difference_threshold}"
   end
 end

--- a/lib/compatriot/assertions.rb
+++ b/lib/compatriot/assertions.rb
@@ -1,0 +1,8 @@
+module Compatriot
+  module Assertions
+    def assert_no_ui_changes(page, title = '')
+      diff = Compatriot.percentage_changed(page, self, title)
+      assert diff <= Compatriot.ui_difference_threshold, "The difference in the page (#{diff}%) is greater then the threshold #{Compatriot.ui_difference_threshold}"
+    end
+  end
+end

--- a/lib/compatriot/assertions.rb
+++ b/lib/compatriot/assertions.rb
@@ -1,7 +1,7 @@
 module Compatriot
   module Assertions
-    def assert_no_ui_changes(page, title = '')
-      diff = Compatriot.percentage_changed(page, self, title)
+    def assert_no_ui_changes(title = '')
+      diff = Compatriot.percentage_changed(self, title)
       assert diff <= Compatriot.ui_difference_threshold, "The difference in the page (#{diff}%) is greater then the threshold #{Compatriot.ui_difference_threshold}"
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ end
 
 class Minitest::Spec
   include TestRunner
+  include Compatriot::Assertions
 end
 
 class Page

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,12 @@ class Minitest::Spec
   include Compatriot::Assertions
 end
 
+module FakeCapybara
+  def self.current_session
+    Page.new
+  end
+end
+
 class Page
   def save_screenshot filepath
     root_dir = File.join(File.dirname(__FILE__), './')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,3 +23,15 @@ end
 class Minitest::Spec
   include TestRunner
 end
+
+class Page
+  def save_screenshot filepath
+    root_dir = File.join(File.dirname(__FILE__), './')
+    image_name = filepath.include?('control') ? '1' : '2'
+    src_img = root_dir + "/images/#{image_name}.png"
+    filepath_dir = File.dirname(filepath)
+    FileUtils.mkdir_p(filepath_dir) unless File.directory?(filepath_dir)
+    FileUtils.cp(src_img, filepath)
+    filepath
+  end
+end

--- a/spec/unit/assertions_spec.rb
+++ b/spec/unit/assertions_spec.rb
@@ -18,6 +18,7 @@ describe Compatriot::Assertions do
     FileUtils.remove_dir(SCREENSHOTS_DIR) if File.directory?(SCREENSHOTS_DIR)
     Compatriot.configure do |config| 
       config.screenshot_directory = SCREENSHOTS_DIR
+      config.framework = FakeCapybara
     end
   end
 

--- a/spec/unit/assertions_spec.rb
+++ b/spec/unit/assertions_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../spec_helper'
+
+describe Compatriot::Assertions do
+  let(:page) { Page.new }
+
+  SCREENSHOTS_DIR      = './tmp/test/screenshots'
+  CONTROL_IMG_FILENAME = 'important_test_will_do_something_important_and_has_a_description.png'
+  CONTROL_IMG          = "#{SCREENSHOTS_DIR}/control/#{CONTROL_IMG_FILENAME}"
+  CONTROL_IMG2         = "#{SCREENSHOTS_DIR}/control/important_test_will_do_something_important_another.png"
+  VARIABLE_IMG         = "#{SCREENSHOTS_DIR}/variable/important_test_will_do_something_important_and_has_a_description.png"
+  DIFF_IMG             = "#{SCREENSHOTS_DIR}/diffs/color_variable_vs_control_important_test_will_do_something_important_and_has_a_description.png"
+
+  def setup_control_image
+    Page.new.save_screenshot CONTROL_IMG
+  end
+
+  before do
+    FileUtils.remove_dir(SCREENSHOTS_DIR) if File.directory?(SCREENSHOTS_DIR)
+    Compatriot.configure do |config| 
+      config.screenshot_directory = SCREENSHOTS_DIR
+    end
+  end
+
+  it 'can assert on assert_no_ui_changes' do
+    assert_no_ui_changes(page, 'this test')
+  end
+end

--- a/spec/unit/assertions_spec.rb
+++ b/spec/unit/assertions_spec.rb
@@ -22,6 +22,6 @@ describe Compatriot::Assertions do
   end
 
   it 'can assert on assert_no_ui_changes' do
-    assert_no_ui_changes(page, 'this test')
+    assert_no_ui_changes('this test')
   end
 end

--- a/spec/unit/compatriot_spec.rb
+++ b/spec/unit/compatriot_spec.rb
@@ -13,18 +13,6 @@ describe Compatriot do
   VARIABLE_IMG         = "#{SCREENSHOTS_DIR}/variable/important_test_will_do_something_important_and_has_a_description.png"
   DIFF_IMG             = "#{SCREENSHOTS_DIR}/diffs/color_variable_vs_control_important_test_will_do_something_important_and_has_a_description.png"
 
-  class Page
-    def save_screenshot filepath
-      root_dir = File.join(File.dirname(__FILE__), '../')
-      image_name = filepath.include?('control') ? '1' : '2'
-      src_img = root_dir + "/images/#{image_name}.png"
-      filepath_dir = File.dirname(filepath)
-      FileUtils.mkdir_p(filepath_dir) unless File.directory?(filepath_dir)
-      FileUtils.cp(src_img, filepath)
-      filepath
-    end
-  end
-
   def setup_control_image
     Page.new.save_screenshot CONTROL_IMG
   end

--- a/spec/unit/compatriot_spec.rb
+++ b/spec/unit/compatriot_spec.rb
@@ -1,5 +1,4 @@
 require_relative '../spec_helper'
-require 'pry'
 
 describe Compatriot do
   let(:class_stub)   { stub_everything('class', name: 'important_test') }

--- a/spec/unit/compatriot_spec.rb
+++ b/spec/unit/compatriot_spec.rb
@@ -20,13 +20,14 @@ describe Compatriot do
     FileUtils.remove_dir(SCREENSHOTS_DIR) if File.directory?(SCREENSHOTS_DIR)
     Compatriot.configure do |config| 
       config.screenshot_directory = SCREENSHOTS_DIR
+      config.framework = FakeCapybara
     end
   end
 
   describe 'no control image is found' do
     it 'it will create one' do
-      Compatriot.take_screenshot(page, stubbed_test, 'and has a description')
-      Compatriot.take_screenshot(page, stubbed_test, 'another')
+      Compatriot.take_screenshot(stubbed_test, 'and has a description')
+      Compatriot.take_screenshot(stubbed_test, 'another')
 
       assert File.exist?(CONTROL_IMG), 'control image not found'
       assert File.exist?(CONTROL_IMG2), 'control image not found'
@@ -39,23 +40,23 @@ describe Compatriot do
     end
 
     it 'stores a variable image' do
-      Compatriot.take_screenshot(page, stubbed_test, 'and has a description')
+      Compatriot.take_screenshot(stubbed_test, 'and has a description')
       assert File.exist?(VARIABLE_IMG)
     end
 
     it 'stores the image difference' do
-      Compatriot.percentage_changed(page, stubbed_test, 'and has a description')
+      Compatriot.percentage_changed( stubbed_test, 'and has a description')
       assert File.exist?(DIFF_IMG)
     end
 
     it 'returns the percentage difference' do
-      result = Compatriot.percentage_changed(page, stubbed_test, 'and has a description')
+      result = Compatriot.percentage_changed( stubbed_test, 'and has a description')
       assert_equal(0.81, result.round(2))
     end
 
     it 'returns 0 % if there is no difference' do
       Compatriot::ColorDiffer.stubs(:diff).returns([])
-      result = Compatriot.percentage_changed(page, stubbed_test, 'and has a description')
+      result = Compatriot.percentage_changed( stubbed_test, 'and has a description')
       assert_equal(0.0, result.round(2))
     end
   end
@@ -71,7 +72,7 @@ describe Compatriot do
     end
 
     it 'can set the screenshot directory' do
-      Compatriot.take_screenshot(page, stubbed_test, 'and has a description')
+      Compatriot.take_screenshot( stubbed_test, 'and has a description')
       assert File.exist?(@control_file), 'control image not found'
     end
   end


### PR DESCRIPTION
It makes more sense for us to define an assertions for a user to use, that way getting setup to use becomes much easier. 

Now, to setup a new project with compatriot in there tests, you just need to 

1. add Compatriot to your gemfile
2. `require 'compatriot'` in your test helper
3. `include Compatriot::Assertions` in your test class

Then to use it, you just add `assert_no_ui_changes(page, 'unique string to avoid collisions in filenames')` to your tests
