### PR TITLE
Produce diff even when dimensions have changed

### DIFF
--- a/lib/compatriot/image_differ/color_differ.rb
+++ b/lib/compatriot/image_differ/color_differ.rb
@@ -13,7 +13,14 @@ module Compatriot
 
       each_pixel(image1) do |x, y|
         pixel1 = image1[x,y]
-        pixel2 = image2[x,y]
+        # If the dimensions of the comparison image are not exactly
+        # the same as image1, ChunkyPNG throws an error and we get
+        # no diff. Let's produce a diff instead
+        begin
+          pixel2 = image2[x,y]
+        rescue ChunkyPNG::OutOfBounds
+          pixel2 = 0 # Make it black
+        end
         unless pixel1 == pixel2
           output[x,y], score = color_difference_of_pixels(pixel1, pixel2)
           diff << score
@@ -32,7 +39,14 @@ module Compatriot
 
       each_pixel(image1) do |x, y|
         pixel1 = image1[x,y]
-        pixel2 = image2[x,y]
+        # If the dimensions of the comparison image are not exactly
+        # the same as image1, ChunkyPNG throws an error and we get
+        # no diff. Let's produce a diff instead
+        begin
+          pixel2 = image2[x,y]
+        rescue ChunkyPNG::OutOfBounds
+          pixel2 = 0 # Make it black
+        end
         unless pixel1 == pixel2
           output[x,y], score = color_difference_of_pixels(pixel1, pixel2)
           diff << score


### PR DESCRIPTION
I was running into a problem when my latest image had dimensions that were different than my control image. The tests would error out with `ChunkyPNG::OutOfBounds` and no diff would be produced. This made it difficult to discover what changes broke the test.
I made this change in my local environment and the tests produced a diff that helped me pinpoint the source of the failures.